### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-type: 'direct'
+      - dependency-name: '*'
+    labels:
+      - 'Dependencies'
+    reviewers:
+      - 'irastypain'


### PR DESCRIPTION
About Dependabot - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates