### PR TITLE
Improve CLI interaction

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,5 +26,8 @@ Metrics/ExampleLength:
   Exclude:
     - spec/**/*_spec.rb
 
+Metrics/MethodLength:
+  Max: 15
+
 Style/Documentation:
   Enabled: false

--- a/lib/rws/cli.rb
+++ b/lib/rws/cli.rb
@@ -29,7 +29,7 @@ module RWS
           exit 0
         end
 
-        option.on '-h, --host HOST', 'Host to bind' do |arg|
+        option.on '-h', '--host HOST', 'Host to bind' do |arg|
           @host = arg
         end
 

--- a/lib/rws/cli.rb
+++ b/lib/rws/cli.rb
@@ -35,6 +35,11 @@ module RWS
         option.on '-p', '--port PORT', 'The TCP port to listen by server' do |arg|
           @port = arg.to_i
         end
+
+        option.on '--version', 'Current version' do
+          puts RWS::VERSION
+          exit 0
+        end
       end
     end
   end

--- a/lib/rws/cli.rb
+++ b/lib/rws/cli.rb
@@ -28,7 +28,7 @@ module RWS
           exit 0
         end
 
-        option.on '--host HOST', 'Host to bind' do |arg|
+        option.on '-h, --host HOST', 'Host to bind' do |arg|
           @host = arg
         end
 

--- a/lib/rws/cli.rb
+++ b/lib/rws/cli.rb
@@ -21,6 +21,7 @@ module RWS
 
     private
 
+    # rubocop:disable Metrics/MethodLength
     def option_parser
       OptionParser.new do |option|
         option.on '--help', 'Print help info' do
@@ -42,5 +43,6 @@ module RWS
         end
       end
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/rws/cli.rb
+++ b/lib/rws/cli.rb
@@ -23,6 +23,11 @@ module RWS
 
     def option_parser
       OptionParser.new do |option|
+        option.on '--help', 'Print help info' do
+          puts option
+          exit 0
+        end
+
         option.on '--host HOST', 'Host to bind' do |arg|
           @host = arg
         end

--- a/spec/rws/cli_spec.rb
+++ b/spec/rws/cli_spec.rb
@@ -44,4 +44,12 @@ RSpec.describe RWS::CLI do
 
     include_examples 'missing option argument', '--host'
   end
+
+  describe '--help' do
+    let(:argv) { ['--help'] }
+
+    it 'prints help info and exit' do
+      expect { run_cli }.to output(/Print help info/).to_stdout.and raise_error(SystemExit)
+    end
+  end
 end

--- a/spec/rws/cli_spec.rb
+++ b/spec/rws/cli_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RWS::CLI do
     include_examples 'missing option argument', '-p'
   end
 
-  describe '--host HOST' do
+  describe '-h, --host HOST' do
     let(:argv) { ['--host', '0.0.0.0'] }
 
     it 'run server with host param' do

--- a/spec/rws/cli_spec.rb
+++ b/spec/rws/cli_spec.rb
@@ -52,4 +52,12 @@ RSpec.describe RWS::CLI do
       expect { run_cli }.to output(/Print help info/).to_stdout.and raise_error(SystemExit)
     end
   end
+
+  describe '--version' do
+    let(:argv) { ['--version'] }
+
+    it 'prints current version and exit' do
+      expect { run_cli }.to output(/#{RWS::VERSION}/).to_stdout.and raise_error(SystemExit)
+    end
+  end
 end


### PR DESCRIPTION
Add new options:
- `--help` - print help info
- `--version` - print current version

Add short option `-h` to specify the host.