### PR TITLE
Add support for config option in CLI

### DIFF
--- a/lib/rws/cli.rb
+++ b/lib/rws/cli.rb
@@ -12,7 +12,7 @@ module RWS
       option_parser(options).parse!(argv.dup)
       exit if options[:need_to_exit]
 
-      RWS::Server.new(**options.slice(:host, :port)).run
+      RWS::Server.new(**options.slice(:host, :port, :config)).run
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -29,6 +29,10 @@ module RWS
 
         option.on '-p', '--port PORT', 'The TCP port to listen by server' do |arg|
           options[:port] = arg.to_i
+        end
+
+        option.on '-c', '--config FILEPATH', 'Path to rackup-compatible config file' do |arg|
+          options[:config] = arg
         end
 
         option.on '--version', 'Current version' do

--- a/lib/rws/configuration.rb
+++ b/lib/rws/configuration.rb
@@ -6,8 +6,8 @@ module RWS
   class Configuration
     DEFAULT_CONFIG_FILE = 'config.ru'
 
-    def initialize(config_file = nil)
-      @config_file = config_file || DEFAULT_CONFIG_FILE
+    def initialize(config_file = DEFAULT_CONFIG_FILE)
+      @config_file = config_file
     end
 
     def load

--- a/lib/rws/server.rb
+++ b/lib/rws/server.rb
@@ -13,10 +13,10 @@ module RWS
     DEFAULT_HOST = '0.0.0.0'
     DEFAULT_PORT = 7890
 
-    def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT)
+    def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, config: nil)
       @host = host
       @port = port
-      @config = RWS::Configuration.new.load
+      @config = RWS::Configuration.new(config).load
     end
 
     def run

--- a/spec/rws/cli_spec.rb
+++ b/spec/rws/cli_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe RWS::CLI do
     allow(RWS::Server).to receive(:new).and_return(server_instance)
   end
 
+  describe '-c, --config FILEPATH' do
+    let(:argv) { ['-c', 'config.ru'] }
+
+    it 'loads config from passed filepath' do
+      run_cli
+
+      expect(RWS::Server).to have_received(:new).with(hash_including(config: 'config.ru'))
+    end
+
+    include_examples 'missing option argument', '-c'
+  end
+
   describe '-p, --port PORT' do
     let(:argv) { ['-p', '8080'] }
 


### PR DESCRIPTION
- pass `-c` or `--config FILEPATH` option to specify rackup-compatible config file path